### PR TITLE
Wrap PersistAsync body into try-catch

### DIFF
--- a/Rsk.Samples.IdentityServer.AdminUiIntegration/Services/CustomEventSink.cs
+++ b/Rsk.Samples.IdentityServer.AdminUiIntegration/Services/CustomEventSink.cs
@@ -24,13 +24,20 @@ namespace Rsk.Samples.IdentityServer.AdminUiIntegration.Services
 
         public Task PersistAsync(Event evt)
         {
-            if (evt == null) throw new ArgumentNullException(nameof(evt));
+            try
+            {
+                if (evt == null) throw new ArgumentNullException(nameof(evt));
 
-            logger.LogInformation("{@event}", evt);
-            
-            if (evt.EventType == EventTypes.Error || evt.EventType == EventTypes.Failure) eventStore.AddEvent(evt); 
-            
-            return Task.CompletedTask;
+                logger.LogInformation("{@event}", evt);
+
+                if (evt.EventType == EventTypes.Error || evt.EventType == EventTypes.Failure) eventStore.AddEvent(evt);
+
+                return Task.CompletedTask;
+            }
+            catch(Exception)
+            {
+                return Task.CompletedTask;
+            }
         }
     }
 

--- a/Rsk.Samples.IdentityServer.AdminUiIntegration/Services/CustomEventSink.cs
+++ b/Rsk.Samples.IdentityServer.AdminUiIntegration/Services/CustomEventSink.cs
@@ -34,9 +34,9 @@ namespace Rsk.Samples.IdentityServer.AdminUiIntegration.Services
 
                 return Task.CompletedTask;
             }
-            catch(Exception)
+            catch(Exception err)
             {
-                logger.LogError("An error occurred while logging and storing an event");
+                logger.LogError(err, "An error occurred while logging and storing an event");
                 return Task.CompletedTask;
             }
         }

--- a/Rsk.Samples.IdentityServer.AdminUiIntegration/Services/CustomEventSink.cs
+++ b/Rsk.Samples.IdentityServer.AdminUiIntegration/Services/CustomEventSink.cs
@@ -36,6 +36,7 @@ namespace Rsk.Samples.IdentityServer.AdminUiIntegration.Services
             }
             catch(Exception)
             {
+                logger.LogError("An error occurred while logging and storing an event");
                 return Task.CompletedTask;
             }
         }


### PR DESCRIPTION
When IdentityServerMiddleware catches and error, it generates an event before logging it. The problem is when raising the event generates another error. This will catch the error generated by events logging so we will be able to see the error hidden behind.